### PR TITLE
Updates JSDOM to be compatible with node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/TJkrusinski/buzzfeed-headlines",
   "dependencies": {
-    "jsdom": "^1.0.0-pre.5"
+    "jsdom": "^7.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1"


### PR DESCRIPTION
Node 4 is only compatible with JSDOM builds 4.0.0 and greater. Tests pass :+1: 
