### PR TITLE
Added error-handler, removed /lists from basePages

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -1,11 +1,13 @@
 'use strict';
 
 var jsdom = require('jsdom');
+var document = jsdom.jsdom(undefined, {
+  virtualConsole: jsdom.createVirtualConsole().sendTo(console)
+});
 
 var basePages = [
   'http://www.buzzfeed.com/life',
   'http://www.buzzfeed.com/quizzes',
-  'http://www.buzzfeed.com/lists',
   'http://www.buzzfeed.com/omg'
   // TODO: add some more pages
 ];


### PR DESCRIPTION
Hey @TJkrusinski, couple quick improvements:

* Added your document var from the clickhole-headlines to surface errors to console (or at least that's what I think it does! I am very new to both NodeJS and JS)
* Removed http://www.buzzfeed.com/lists from basePages, it's no longer a live page on Buzzfeed. it currently redirects to http://www.buzzfeed.com/buzz